### PR TITLE
Support fragments in links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Node: Add `Fragment` field to track the `#` portion of a link.
+
+### Changed
+- Parser: Pull apart `#` portion of a link into Fragment field.
+- Renderer: Support links without titles. This makes wikilink references to
+  headers in the same document possible with `[[#Foo]]` possible.
+
 ## [0.1.0] - 2021-03-14
 - Initial release.
 

--- a/ast.go
+++ b/ast.go
@@ -25,7 +25,16 @@ type Node struct {
 	ast.BaseInline
 
 	// Page to which this wikilink points.
+	//
+	// This may be blank for links to headers within the same document
+	// like [[#Foo]].
 	Target []byte
+
+	// Fragment portion of the link, if any.
+	//
+	// For links in the form, [[Foo bar#Baz qux]], this is the portion
+	// after the "#".
+	Fragment []byte
 }
 
 var _ ast.Node = (*Node)(nil)

--- a/parser.go
+++ b/parser.go
@@ -26,6 +26,7 @@ var _ parser.InlineParser = (*Parser)(nil)
 var (
 	_open  = []byte("[[")
 	_pipe  = []byte{'|'}
+	_hash  = []byte{'#'}
 	_close = []byte("]]")
 )
 
@@ -68,6 +69,12 @@ func (p *Parser) Parse(_ ast.Node, block text.Reader, _ parser.Context) ast.Node
 
 	if len(n.Target) == 0 || seg.Len() == 0 {
 		return nil // target and label must not be empty
+	}
+
+	// Target may be Foo#Bar, so break them apart.
+	if idx := bytes.LastIndex(n.Target, _hash); idx >= 0 {
+		n.Fragment = n.Target[idx+1:] // Foo#Bar => Bar
+		n.Target = n.Target[:idx]     // Foo#Bar => Foo
 	}
 
 	n.AppendChild(n, ast.NewTextSegment(seg))

--- a/parser_test.go
+++ b/parser_test.go
@@ -17,8 +17,9 @@ func TestParser(t *testing.T) {
 		desc string
 		give string
 
-		wantTarget string
-		wantLabel  string
+		wantTarget   string
+		wantLabel    string
+		wantFragment string
 
 		remainder string // unconsumed portion of tt.give
 	}{
@@ -49,6 +50,35 @@ func TestParser(t *testing.T) {
 			wantLabel:  "baz qux",
 			remainder:  " quux",
 		},
+		{
+			desc:         "fragment",
+			give:         "[[foo#bar]] baz",
+			wantTarget:   "foo",
+			wantLabel:    "foo#bar",
+			wantFragment: "bar",
+			remainder:    " baz",
+		},
+		{
+			desc:         "fragment with label",
+			give:         "[[foo#bar|baz]]",
+			wantTarget:   "foo",
+			wantLabel:    "baz",
+			wantFragment: "bar",
+		},
+		{
+			desc:         "fragment without target",
+			give:         "[[#foo]]",
+			wantTarget:   "",
+			wantLabel:    "#foo",
+			wantFragment: "foo",
+		},
+		{
+			desc:         "fragment without target with label",
+			give:         "[[#foo|bar]]",
+			wantTarget:   "",
+			wantLabel:    "bar",
+			wantFragment: "foo",
+		},
 	}
 
 	for _, tt := range tests {
@@ -64,6 +94,7 @@ func TestParser(t *testing.T) {
 
 			if n, ok := got.(*Node); assert.True(t, ok, "expected Node, got %T", got) {
 				assert.Equal(t, tt.wantTarget, string(n.Target), "target mismatch")
+				assert.Equal(t, tt.wantFragment, string(n.Fragment), "fragment mismatch")
 			}
 
 			if assert.Equal(t, 1, got.ChildCount(), "children mismatch") {

--- a/resolver.go
+++ b/resolver.go
@@ -26,8 +26,15 @@ var _html = []byte(".html")
 type defaultResolver struct{}
 
 func (defaultResolver) ResolveWikilink(n *Node) ([]byte, error) {
-	dest := make([]byte, len(n.Target)+len(_html))
-	copy(dest, n.Target)
-	copy(dest[len(n.Target):], _html)
-	return dest, nil
+	dest := make([]byte, len(n.Target)+len(_html)+len(_hash)+len(n.Fragment))
+	var i int
+	if len(n.Target) > 0 {
+		i += copy(dest, n.Target)
+		i += copy(dest[i:], _html)
+	}
+	if len(n.Fragment) > 0 {
+		i += copy(dest[i:], _hash)
+		i += copy(dest[i:], n.Fragment)
+	}
+	return dest[:i], nil
 }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,6 +1,7 @@
 package wikilink
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,21 +18,47 @@ func TestDefaultResolver(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		give string
-		want string
+		target   string
+		fragment string
+		want     string
 	}{
-		{"foo", "foo.html"},
-		{"foo bar", "foo bar.html"},
-		{"foo/bar", "foo/bar.html"},
+		{
+			target: "foo",
+			want:   "foo.html",
+		},
+		{
+			target: "foo bar",
+			want:   "foo bar.html",
+		},
+		{
+			target: "foo/bar",
+			want:   "foo/bar.html",
+		},
+		{
+			target:   "foo",
+			fragment: "bar",
+			want:     "foo.html#bar",
+		},
+		{
+			target:   "foo/bar",
+			fragment: "baz",
+			want:     "foo/bar.html#baz",
+		},
+		{
+			fragment: "foo",
+			want:     "#foo",
+		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run(tt.give, func(t *testing.T) {
+		name := fmt.Sprintf("%v#%v", tt.target, tt.fragment)
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
 			got, err := DefaultResolver.ResolveWikilink(&Node{
-				Target: []byte(tt.give),
+				Target:   []byte(tt.target),
+				Fragment: []byte(tt.fragment),
 			})
 			require.NoError(t, err, "resolve failed")
 			assert.Equal(t, tt.want, string(got), "result mismatch")

--- a/testdata/integration_test.txt
+++ b/testdata/integration_test.txt
@@ -68,3 +68,27 @@ Does not mess up [regular links](dest.html).
 //- - - - - - - - -//
 <p>Does not mess up <a href="dest.html">regular links</a>.</p>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+12
+//- - - - - - - - -//
+Supports [[Fragments#In Links]].
+//- - - - - - - - -//
+<p>Supports <a href="Fragments.html#In%20Links">Fragments#In Links</a>.</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+13
+//- - - - - - - - -//
+Links [[with fragments#can have|labels]].
+//- - - - - - - - -//
+<p>Links <a href="with%20fragments.html#can%20have">labels</a>.</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+14
+//- - - - - - - - -//
+[[#Relative]] links.
+//- - - - - - - - -//
+<p><a href="#Relative">#Relative</a> links.</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+15
+//- - - - - - - - -//
+Relative [[#Links|with labels]].
+//- - - - - - - - -//
+<p>Relative <a href="#Links">with labels</a>.</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//


### PR DESCRIPTION
Separately parse the `#`-portion of a reference in a wikilink so that
references like the following are valid and easy to process in the
resolver.

    [[Foo#Bar]]
    [[#Foo]]

The latter is important to make references to headers in the same
document.

These are still passed to the resolver to manipulate as needed.
This is necessary because some wikilink formats allow these to be full
names of headers (`[[#Some section]]`) while others prefer IDs of those
headers (`[[#some-section]]`).