### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.2.0] - 2021-03-23
 ### Added
 - Node: Add `Fragment` field to track the `#` portion of a link.
 
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parser: Pull apart `#` portion of a link into Fragment field.
 - Renderer: Support links without titles. This makes wikilink references to
   headers in the same document possible with `[[#Foo]]` possible.
+
+[0.2.0]: https://github.com/abhinav/goldmark-wikilink/releases/tag/v0.2.0
 
 ## [0.1.0] - 2021-03-14
 - Initial release.


### PR DESCRIPTION
### Added
- Node: Add `Fragment` field to track the `#` portion of a link.

### Changed
- Parser: Pull apart `#` portion of a link into Fragment field.
- Renderer: Support links without titles. This makes wikilink references to
  headers in the same document possible with `[[#Foo]]` possible.
