### PR TITLE
renderer: Skip links without destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Renderer: Don't render links if Resolver returns an empty destination.
+
 ## [0.2.0] - 2021-03-23
 ### Added
 - Node: Add `Fragment` field to track the `#` portion of a link.

--- a/extender.go
+++ b/extender.go
@@ -31,7 +31,7 @@ func (e *Extender) Extend(md goldmark.Markdown) {
 	md.Renderer().AddOptions(
 		renderer.WithNodeRenderers(
 			util.Prioritized(&Renderer{
-				e.Resolver,
+				Resolver: e.Resolver,
 			}, 199),
 		),
 	)

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,6 +1,7 @@
 package wikilink_test
 
 import (
+	"bytes"
 	"testing"
 
 	wikilink "github.com/abhinav/goldmark-wikilink"
@@ -12,8 +13,27 @@ func TestIntegration(t *testing.T) {
 	t.Parallel()
 
 	goldtestutil.DoTestCaseFile(
-		goldmark.New(goldmark.WithExtensions(&wikilink.Extender{})),
-		"testdata/integration_test.txt",
+		goldmark.New(goldmark.WithExtensions(&wikilink.Extender{
+			Resolver: _resolver,
+		})),
+		"testdata/tests.txt",
 		t,
 	)
+}
+
+var (
+	_resolver = resolver{}
+
+	// Links with this target will return a nil destination.
+	_doesNotExistTarget = []byte("Does Not Exist")
+)
+
+type resolver struct{}
+
+func (resolver) ResolveWikilink(n *wikilink.Node) ([]byte, error) {
+	if bytes.Equal(n.Target, _doesNotExistTarget) {
+		return nil, nil
+	}
+
+	return wikilink.DefaultResolver.ResolveWikilink(n)
 }

--- a/renderer.go
+++ b/renderer.go
@@ -2,6 +2,7 @@ package wikilink
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
@@ -16,10 +17,35 @@ import (
 //   wikilinkRenderer := util.Prioritized(&wikilink.Renderer{...}, 199)
 //   goldmarkRenderer.AddOptions(renderer.WithNodeRenderers(wikilinkRenderer))
 type Renderer struct {
-	// Resolver determines how destinations for wikilink pages.
+	// Resolver determines destinations for wikilink pages.
 	//
-	// Uses DefaultResolver if unspecified.
+	// If a Resolver returns an empty destination, the Renderer will skip
+	// the link and render just its contents. That is, instead of,
+	//
+	//   <a href="foo">bar</a>
+	//
+	// The renderer will render just the following.
+	//
+	//   bar
+	//
+	// Defaults to DefaultResolver if unspecified.
 	Resolver Resolver
+
+	once sync.Once // guards init
+
+	// hasDest records whether a node had a destination when we resolved
+	// it. This is needed to decide whether a closing </a> must be added
+	// when exiting a Node render.
+	hasDest map[*Node]struct{}
+}
+
+func (r *Renderer) init() {
+	r.once.Do(func() {
+		r.hasDest = make(map[*Node]struct{})
+		if r.Resolver == nil {
+			r.Resolver = DefaultResolver
+		}
+	})
 }
 
 // RegisterFuncs registers wikilink rendering functions with the provided
@@ -34,31 +60,47 @@ func (r *Renderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 // goldmark will call this method if this renderer was registered with it
 // using the WithNodeRenderers option.
 func (r *Renderer) Render(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	r.init()
+
 	n, ok := node.(*Node)
 	if !ok {
 		return ast.WalkStop, fmt.Errorf("unexpected node %T, expected *goldmarkwikilink.Node", node)
 	}
 
 	if entering {
-		dest, err := r.resolve(n)
-		if err != nil {
-			return ast.WalkStop, fmt.Errorf("resolve %q: %w", n.Target, err)
+		if err := r.enter(w, n); err != nil {
+			return ast.WalkStop, err
 		}
-
-		w.WriteString(`<a href="`)
-		w.Write(util.URLEscape(dest, true /* resolve references */))
-		w.WriteString(`">`)
 	} else {
-		w.WriteString("</a>")
+		r.exit(w, n)
 	}
 
 	return ast.WalkContinue, nil
 }
 
-func (r *Renderer) resolve(n *Node) ([]byte, error) {
-	res := r.Resolver
-	if res == nil {
-		res = DefaultResolver
+func (r *Renderer) enter(w util.BufWriter, n *Node) error {
+	dest, err := r.Resolver.ResolveWikilink(n)
+	if err != nil {
+		return fmt.Errorf("resolve %q: %w", n.Target, err)
 	}
-	return res.ResolveWikilink(n)
+	if len(dest) == 0 {
+		return nil
+	}
+
+	r.hasDest[n] = struct{}{}
+	w.WriteString(`<a href="`)
+	w.Write(util.URLEscape(dest, true /* resolve references */))
+	w.WriteString(`">`)
+	return nil
+}
+
+func (r *Renderer) exit(w util.BufWriter, n *Node) {
+	_, ok := r.hasDest[n]
+	if !ok {
+		return
+	}
+
+	w.WriteString("</a>")
+	// Avoid memory leaks by cleaning up after exiting the node.
+	delete(r.hasDest, n)
 }

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -63,6 +63,28 @@ func TestRenderer(t *testing.T) {
 		assert.Equal(t, `<a href="bar.html">`, buff.String(),
 			"output mismatch")
 	})
+
+	t.Run("no link", func(t *testing.T) {
+		t.Parallel()
+		var (
+			buff bytes.Buffer
+			w    = bufio.NewWriter(&buff)
+		)
+
+		n := &Node{Target: []byte("foo")}
+		r := Renderer{
+			Resolver: resolverFunc(noopResolver),
+		}
+
+		_, err := r.Render(w, nil /* source */, n, true /* entering */)
+		require.NoError(t, err, "should not fail")
+
+		_, err = r.Render(w, nil /* source */, n, false /* entering */)
+		require.NoError(t, err, "should not fail")
+
+		require.NoError(t, w.Flush(), "flush")
+		assert.Empty(t, buff.String(), "output should be empty")
+	})
 }
 
 func TestRenderer_IncorrectNode(t *testing.T) {
@@ -90,4 +112,8 @@ func TestRenderer_ResolveError(t *testing.T) {
 	)
 	require.Error(t, err, "render with incorrect node must fail")
 	assert.Contains(t, err.Error(), "great sadness")
+}
+
+func noopResolver(*Node) ([]byte, error) {
+	return nil, nil
 }

--- a/resolver.go
+++ b/resolver.go
@@ -18,6 +18,10 @@ type Resolver interface {
 	//
 	// If ResolveWikilink returns a non-nil error, rendering will be
 	// halted.
+	//
+	// If ResolveWikilink returns a nil destination and error, the
+	// Renderer will omit the link and render its contents as a regular
+	// string.
 	ResolveWikilink(*Node) (destination []byte, err error)
 }
 

--- a/testdata/tests.txt
+++ b/testdata/tests.txt
@@ -92,3 +92,15 @@ Relative [[#Links|with labels]].
 //- - - - - - - - -//
 <p>Relative <a href="#Links">with labels</a>.</p>
 //= = = = = = = = = = = = = = = = = = = = = = = =//
+16
+//- - - - - - - - -//
+Page that [[Does Not Exist]].
+//- - - - - - - - -//
+<p>Page that Does Not Exist.</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//
+17
+//- - - - - - - - -//
+Page that [[Does Not Exist|has a label]].
+//- - - - - - - - -//
+<p>Page that has a label.</p>
+//= = = = = = = = = = = = = = = = = = = = = = = =//


### PR DESCRIPTION
If the Resolver returns an empty destination for a wikilink Node, don't
render a link for it. For empty destinations, this changes the output
from the following,

    <a href="">Foo</a>

To the following,

    Foo
