### PR TITLE
Turn into shim

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ '*' ]
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 - 2023-02-11
+### Changed
+- Turn module into a shim around go.abhg.dev/goldmark/wikilink.
+
 ## [0.3.0] - 2021-03-25
 ### Changed
 - Renderer: Don't render links if Resolver returns an empty destination.

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,11 @@ golint: $(GOLINT)
 
 .PHONY: staticcheck
 staticcheck: $(STATICCHECK)
-	$(STATICCHECK) ./...
+	$(eval STATICCHECK_LOG := $(shell mktemp -t staticcheck.XXXXX))
+	$(STATICCHECK) ./... | grep -v SA1019 > $(STATICCHECK_LOG) || true
+	@[ ! -s "$(STATICCHECK_LOG)" ] || \
+		 (echo "static failed:" | \
+		 cat - $(STATICCHECK_LOG) && false)
 
 tools: $(GOLINT) $(STATICCHECK)
 

--- a/ast.go
+++ b/ast.go
@@ -1,11 +1,9 @@
 package wikilink
 
-import (
-	"github.com/yuin/goldmark/ast"
-)
+import "go.abhg.dev/goldmark/wikilink"
 
 // Kind is the kind of the wikilink AST node.
-var Kind = ast.NewNodeKind("WikiLink")
+var Kind = wikilink.Kind
 
 // Node is a Wikilink AST node. Wikilinks have two components: the target and
 // the label.
@@ -15,38 +13,10 @@ var Kind = ast.NewNodeKind("WikiLink")
 //
 // For links in the following form, the label and the target are the same.
 //
-//   [[Foo bar]]
+//	[[Foo bar]]
 //
 // For links in the following form, the target is the portion of the link to
 // the left of the "|", and the label is the portion to the right.
 //
-//   [[Foo bar|baz qux]]
-type Node struct {
-	ast.BaseInline
-
-	// Page to which this wikilink points.
-	//
-	// This may be blank for links to headers within the same document
-	// like [[#Foo]].
-	Target []byte
-
-	// Fragment portion of the link, if any.
-	//
-	// For links in the form, [[Foo bar#Baz qux]], this is the portion
-	// after the "#".
-	Fragment []byte
-}
-
-var _ ast.Node = (*Node)(nil)
-
-// Kind reports the kind of this node.
-func (n *Node) Kind() ast.NodeKind {
-	return Kind
-}
-
-// Dump dumps the Node to stdout.
-func (n *Node) Dump(src []byte, level int) {
-	ast.DumpHelper(n, src, level, map[string]string{
-		"Target": string(n.Target),
-	}, nil)
-}
+//	[[Foo bar|baz qux]]
+type Node = wikilink.Node

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// Deprecated: Use "go.abhg.dev/goldmark/wikilink" instead.
+package wikilink

--- a/extender.go
+++ b/extender.go
@@ -1,38 +1,7 @@
 package wikilink
 
-import (
-	"github.com/yuin/goldmark"
-	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/renderer"
-	"github.com/yuin/goldmark/util"
-)
+import "go.abhg.dev/goldmark/wikilink"
 
 // Extender extends a goldmark Markdown object with support for parsing and
 // rendering Wikilinks.
-type Extender struct {
-	// Resoler specifies how to resolve destinations for linked pages.
-	//
-	// Uses DefaultResolver if unspecified.
-	Resolver Resolver
-}
-
-// Extend extends the provided Markdown object with support for wikilinks.
-func (e *Extender) Extend(md goldmark.Markdown) {
-	// The link parser is at priority 200 in goldmark so we need to be
-	// lower than that to ensure that the "[" trigger fires.
-	md.Parser().AddOptions(
-		parser.WithInlineParsers(
-			util.Prioritized(&Parser{}, 199),
-		),
-	)
-
-	// The renderer priority matters less. Use the same just so that
-	// there's a reasonable expected value.
-	md.Renderer().AddOptions(
-		renderer.WithNodeRenderers(
-			util.Prioritized(&Renderer{
-				Resolver: e.Resolver,
-			}, 199),
-		),
-	)
-}
+type Extender = wikilink.Extender

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use "go.abhg.dev/goldmark/wikilink" instead.
 module github.com/abhinav/goldmark-wikilink
 
 go 1.16
@@ -5,4 +6,5 @@ go 1.16
 require (
 	github.com/stretchr/testify v1.7.0
 	github.com/yuin/goldmark v1.1.32
+	go.abhg.dev/goldmark/wikilink v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,10 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.32 h1:5tjfNdR2ki3yYQ842+eX2sQHeiwpKJ0RnHO4IYOc4V8=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.abhg.dev/goldmark/wikilink v0.4.0 h1:SijoYzL5imcNj45TEc8+M/qmKvnoElfhdDr4lC5O0a0=
+go.abhg.dev/goldmark/wikilink v0.4.0/go.mod h1:41j3kwAgtVVqPNxKlSSigFFYMPbiCrz9fA9Vjeo/cTs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/parser.go
+++ b/parser.go
@@ -1,83 +1,15 @@
 package wikilink
 
-import (
-	"bytes"
-
-	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/text"
-)
+import "go.abhg.dev/goldmark/wikilink"
 
 // Parser parses wikilinks.
 //
 // Install it on your goldmark Markdown object with Extender, or install it
 // directly on your goldmark Parser by using the WithInlineParsers option.
 //
-//   wikilinkParser := util.Prioritized(&wikilink.Parser{...}, 199)
-//   goldmarkParser.AddOptions(parser.WithInlineParsers(wikilinkParser))
+//	wikilinkParser := util.Prioritized(&wikilink.Parser{...}, 199)
+//	goldmarkParser.AddOptions(parser.WithInlineParsers(wikilinkParser))
 //
 // Note that the priority for the wikilink parser must 199 or lower to take
 // precednce over the plain Markdown link parser which has a priority of 200.
-type Parser struct {
-}
-
-var _ parser.InlineParser = (*Parser)(nil)
-
-var (
-	_open  = []byte("[[")
-	_pipe  = []byte{'|'}
-	_hash  = []byte{'#'}
-	_close = []byte("]]")
-)
-
-// Trigger returns characters that trigger this parser.
-func (p *Parser) Trigger() []byte {
-	return []byte{'['}
-}
-
-// Parse parses a wikilink. It supports links in the following form.
-//
-//   [[My page]]
-//
-// This will use "My page" as both, the target for the link as well as the
-// plain text label for it.
-//
-// Optionally, links can specify a different label by adding a "|" after the
-// target.
-//
-//   [[My page|click here]]
-//
-// This will treat "My page" as the target and "click here" as the label for
-// the link.
-func (p *Parser) Parse(_ ast.Node, block text.Reader, _ parser.Context) ast.Node {
-	line, seg := block.PeekLine()
-	if !bytes.HasPrefix(line, _open) {
-		return nil
-	}
-
-	stop := bytes.Index(line, _close)
-	if stop < 0 {
-		return nil // must close on the same ine
-	}
-	seg = text.NewSegment(seg.Start+2, seg.Start+stop)
-
-	n := &Node{Target: block.Value(seg)}
-	if idx := bytes.Index(n.Target, _pipe); idx >= 0 {
-		n.Target = n.Target[:idx]                // [[ ... |
-		seg = seg.WithStart(seg.Start + idx + 1) // | ... ]]
-	}
-
-	if len(n.Target) == 0 || seg.Len() == 0 {
-		return nil // target and label must not be empty
-	}
-
-	// Target may be Foo#Bar, so break them apart.
-	if idx := bytes.LastIndex(n.Target, _hash); idx >= 0 {
-		n.Fragment = n.Target[idx+1:] // Foo#Bar => Bar
-		n.Target = n.Target[:idx]     // Foo#Bar => Foo
-	}
-
-	n.AppendChild(n, ast.NewTextSegment(seg))
-	block.Advance(stop + 2)
-	return n
-}
+type Parser = wikilink.Parser

--- a/renderer.go
+++ b/renderer.go
@@ -1,106 +1,12 @@
 package wikilink
 
-import (
-	"fmt"
-	"sync"
-
-	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/renderer"
-	"github.com/yuin/goldmark/util"
-)
+import "go.abhg.dev/goldmark/wikilink"
 
 // Renderer renders wikilinks as HTML.
 //
 // Install it on your goldmark Markdown object with Extender, or directly on a
 // goldmark Renderer by using the WithNodeRenderers option.
 //
-//   wikilinkRenderer := util.Prioritized(&wikilink.Renderer{...}, 199)
-//   goldmarkRenderer.AddOptions(renderer.WithNodeRenderers(wikilinkRenderer))
-type Renderer struct {
-	// Resolver determines destinations for wikilink pages.
-	//
-	// If a Resolver returns an empty destination, the Renderer will skip
-	// the link and render just its contents. That is, instead of,
-	//
-	//   <a href="foo">bar</a>
-	//
-	// The renderer will render just the following.
-	//
-	//   bar
-	//
-	// Defaults to DefaultResolver if unspecified.
-	Resolver Resolver
-
-	once sync.Once // guards init
-
-	// hasDest records whether a node had a destination when we resolved
-	// it. This is needed to decide whether a closing </a> must be added
-	// when exiting a Node render.
-	hasDest map[*Node]struct{}
-}
-
-func (r *Renderer) init() {
-	r.once.Do(func() {
-		r.hasDest = make(map[*Node]struct{})
-		if r.Resolver == nil {
-			r.Resolver = DefaultResolver
-		}
-	})
-}
-
-// RegisterFuncs registers wikilink rendering functions with the provided
-// goldmark registerer. This teaches goldmark to call us when it encounters a
-// wikilink in the AST.
-func (r *Renderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
-	reg.Register(Kind, r.Render)
-}
-
-// Render renders the provided Node. It must be a Wikilink node.
-//
-// goldmark will call this method if this renderer was registered with it
-// using the WithNodeRenderers option.
-func (r *Renderer) Render(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	r.init()
-
-	n, ok := node.(*Node)
-	if !ok {
-		return ast.WalkStop, fmt.Errorf("unexpected node %T, expected *goldmarkwikilink.Node", node)
-	}
-
-	if entering {
-		if err := r.enter(w, n); err != nil {
-			return ast.WalkStop, err
-		}
-	} else {
-		r.exit(w, n)
-	}
-
-	return ast.WalkContinue, nil
-}
-
-func (r *Renderer) enter(w util.BufWriter, n *Node) error {
-	dest, err := r.Resolver.ResolveWikilink(n)
-	if err != nil {
-		return fmt.Errorf("resolve %q: %w", n.Target, err)
-	}
-	if len(dest) == 0 {
-		return nil
-	}
-
-	r.hasDest[n] = struct{}{}
-	w.WriteString(`<a href="`)
-	w.Write(util.URLEscape(dest, true /* resolve references */))
-	w.WriteString(`">`)
-	return nil
-}
-
-func (r *Renderer) exit(w util.BufWriter, n *Node) {
-	_, ok := r.hasDest[n]
-	if !ok {
-		return
-	}
-
-	w.WriteString("</a>")
-	// Avoid memory leaks by cleaning up after exiting the node.
-	delete(r.hasDest, n)
-}
+//	wikilinkRenderer := util.Prioritized(&wikilink.Renderer{...}, 199)
+//	goldmarkRenderer.AddOptions(renderer.WithNodeRenderers(wikilinkRenderer))
+type Renderer = wikilink.Renderer

--- a/resolver.go
+++ b/resolver.go
@@ -1,44 +1,16 @@
 package wikilink
 
+import "go.abhg.dev/goldmark/wikilink"
+
 // DefaultResolver is a minimal wiklink resolver that resolves to HTML pages
 // relative to the source page.
 //
 // For example,
 //
-//  [[Foo]]      // => "Foo.html"
-//  [[Foo bar]]  // => "Foo bar.html"
-//  [[foo/Bar]]  // => "foo/Bar.html"
-var DefaultResolver Resolver = defaultResolver{}
+//	[[Foo]]      // => "Foo.html"
+//	[[Foo bar]]  // => "Foo bar.html"
+//	[[foo/Bar]]  // => "foo/Bar.html"
+var DefaultResolver Resolver = wikilink.DefaultResolver
 
 // Resolver resolves pages referenced by wikilinks to their destinations.
-type Resolver interface {
-	// ResolveWikilink returns the address of the page that the provided
-	// wikilink points to. The destination will be URL-escaped before
-	// being placed into a link.
-	//
-	// If ResolveWikilink returns a non-nil error, rendering will be
-	// halted.
-	//
-	// If ResolveWikilink returns a nil destination and error, the
-	// Renderer will omit the link and render its contents as a regular
-	// string.
-	ResolveWikilink(*Node) (destination []byte, err error)
-}
-
-var _html = []byte(".html")
-
-type defaultResolver struct{}
-
-func (defaultResolver) ResolveWikilink(n *Node) ([]byte, error) {
-	dest := make([]byte, len(n.Target)+len(_html)+len(_hash)+len(n.Fragment))
-	var i int
-	if len(n.Target) > 0 {
-		i += copy(dest, n.Target)
-		i += copy(dest[i:], _html)
-	}
-	if len(n.Fragment) > 0 {
-		i += copy(dest[i:], _hash)
-		i += copy(dest[i:], n.Fragment)
-	}
-	return dest[:i], nil
-}
+type Resolver = wikilink.Resolver


### PR DESCRIPTION
Turns the v0.3 release with the GitHub URL
into a shim around v0.4 with the go.abhg.dev URL.
