### PR TITLE
renderer: Fix hasDest data race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default resolver now adds the `.html` suffix to a target
   only if the target does not already have an extension.
 
+### Fixed
+- Fix data race in node destination tracking in the Renderer.
+
 ## [0.4.0] - 2022-12-19
 ### Changed
 - Change the module path to `go.abhg.dev/goldmark/wikilink`.


### PR DESCRIPTION
hasDest is written to and read from multiple goroutines
at the same time.
Use a sync.Map to avoid the data race.

Also avoids having to check if a node is an image again
because hasDest gets an entry only if it's specifically not.