### PR TITLE
Add demo website

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "gomod"
+    directory: "/demo"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,4 +1,4 @@
-name: Publish API Reference
+name: Publish documentation
 
 on:
   # Publish documentation when a new release is tagged.
@@ -40,6 +40,10 @@ jobs:
         run: go install go.abhg.dev/doc2go@latest
       - name: Generate API reference
         run: doc2go -home go.abhg.dev/goldmark/wikilink  ./...
+      - name: Build demo website
+        run: |
+          make -C demo
+          cp -r demo/static _site/demo
       - name: Upload pages
         uses: actions/upload-pages-artifact@v1
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ and `![[...]]`-style embedded wiki links.
 
   [goldmark]: http://github.com/yuin/goldmark
 
+**Demo**:
+A web-based demonstration of the extension is available at
+<https://abhinav.github.io/goldmark-hashtag/demo/>.
+
 ## Installation
 
 ```bash

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,0 +1,12 @@
+OUT = static
+
+.PHONY: all
+all: $(OUT)/wasm_exec.js $(OUT)/main.wasm
+
+$(OUT)/wasm_exec.js:
+	@mkdir -p $(OUT)
+	cp "$(shell go env GOROOT)/misc/wasm/wasm_exec.js" $@
+
+$(OUT)/main.wasm: $(wildcard *.go)
+	@mkdir -p $(OUT)
+	GOOS=js GOARCH=wasm go build -o $@

--- a/demo/go.mod
+++ b/demo/go.mod
@@ -1,0 +1,10 @@
+module go.abhg.dev/goldmark/wikilink/demo
+
+go 1.20
+
+replace go.abhg.dev/goldmark/wikilink => ../
+
+require (
+	github.com/yuin/goldmark v1.5.4
+	go.abhg.dev/goldmark/wikilink v0.4.0
+)

--- a/demo/go.sum
+++ b/demo/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.5.4 h1:2uY/xC0roWy8IBEGLgB1ywIoEJFGmRrX21YQcvGZzjU=
+github.com/yuin/goldmark v1.5.4/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/demo/main.go
+++ b/demo/main.go
@@ -1,0 +1,43 @@
+// demo implements a WASM module that can be used to format markdown
+// with the goldmark-wikilink extension.
+package main
+
+import (
+	"bytes"
+	"syscall/js"
+
+	"github.com/yuin/goldmark"
+	"go.abhg.dev/goldmark/wikilink"
+)
+
+func main() {
+	js.Global().Set("renderWikilinks", js.FuncOf(func(this js.Value, args []js.Value) any {
+		return renderWikilinks(args[0].String()).Encode()
+	}))
+
+	select {}
+}
+
+type response struct {
+	HTML string
+}
+
+func (r *response) Encode() js.Value {
+	return js.ValueOf(map[string]any{
+		"html": r.HTML,
+	})
+}
+
+func renderWikilinks(markdown string) *response {
+	md := goldmark.New(
+		goldmark.WithExtensions(
+			&wikilink.Extender{},
+		),
+	)
+
+	var buff bytes.Buffer
+	md.Convert([]byte(markdown), &buff)
+	return &response{
+		HTML: buff.String(),
+	}
+}

--- a/demo/static/.gitignore
+++ b/demo/static/.gitignore
@@ -1,0 +1,2 @@
+/wasm_exec.js
+/main.wasm

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>goldmark-wikilink</title>
+    <script src="wasm_exec.js"></script>
+    <script>
+      const go = new Go();
+      WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then((result) => {
+        go.run(result.instance);
+      });
+    </script>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+      .container {
+        max-width: 100%;
+        margin: 0 auto;
+        position: relative;
+      }
+      .input-container {
+        border: 1px solid #ccc;
+        padding: 1em;
+        top: 0;
+        left: 0;
+        width: 45%;
+        position: absolute;
+      }
+      .output-container {
+        border: 1px solid #ccc;
+        padding: 1em;
+        top: 0;
+        left: 50%;
+        width: 45%;
+        position: absolute;
+      }
+
+      #input {
+        width: 100%;
+        height: 60vh;
+      }
+    </style>
+  </head>
+  <body>
+    <center>
+      <h1><a href="https://github.com/abhinav/goldmark-wikilink">goldmark-wikilink</a></h1>
+    </center>
+
+    <div class="container">
+      <div class="input-container">
+        <h2>Input</h2>
+        <textarea id="input" rows="10" cols="80"></textarea>
+      </div>
+
+      <div class="output-container">
+        <h2>Output</h2>
+        <div id="output"></div>
+      </div>
+    </div>
+  </body>
+
+  <script>
+    const input = document.getElementById("input");
+    const output = document.getElementById("output");
+
+    input.addEventListener("input", refresh);
+
+    function refresh() {
+      const res = renderWikilinks(input.value);
+      output.innerHTML = res.html;
+    }
+  </script>
+</html>


### PR DESCRIPTION
Adds a demo website to the published documentation.
It uses WASM to preview the effect of the plugin
on a static web page.
