### PR TITLE
ci: Test with Go 1.21, drop 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.19.x", "1.20.x"]
+        go: ["1.20.x", "1.21.x"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
With the release of Go 1.21, Go 1.19 is no longer supported.
Test with Go 1.20 and 1.21.
