### PR TITLE
Replace instances of wiklink with wikilink

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use goldmark-wikilink, import the `wikilink` package.
 import "go.abhg.dev/goldmark/wikilink"
 ```
 
-Then include the `wiklink.Extender` in the list of extensions
+Then include the `wikilink.Extender` in the list of extensions
 that you build your [`goldmark.Markdown`] with.
 
   [`goldmark.Markdown`]: https://pkg.go.dev/github.com/yuin/goldmark#Markdown
@@ -36,7 +36,7 @@ that you build your [`goldmark.Markdown`] with.
 ```go
 goldmark.New(
   goldmark.WithExtensions(
-    &wiklink.Extender{},
+    &wikilink.Extender{},
   ),
   // ...
 )
@@ -61,7 +61,7 @@ to your `wikilink.Extender` when you install it.
 goldmark.New(
   goldmark.WithExtensions(
     // ...
-    &wiklink.Extender{
+    &wikilink.Extender{
       Resolver: myresolver,
     },
   ),

--- a/resolver.go
+++ b/resolver.go
@@ -2,7 +2,7 @@ package wikilink
 
 import "path/filepath"
 
-// DefaultResolver is a minimal wiklink resolver that resolves wikilinks
+// DefaultResolver is a minimal wikilink resolver that resolves wikilinks
 // relative to the source page.
 //
 // It adds ".html" to the end of the target


### PR DESCRIPTION
I copied the code from the readme to start a project using this, and ran into an issue due to the example code referencing the package as `wiklink` rather than `wikilink`.

Did a find & replace in the project for `wiklink`, replacing it with `wikilink`, so the example code in the README should now be valid.